### PR TITLE
docs: refresh p50 column for C1/C2/C4/C5 after vtebench fixture fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,19 +10,21 @@ MVP shipped. Plan 2A extends to 7 throughput cells (C1-C5, C10, C11) with mode-a
 
 ## Baseline (Plan 2A)
 
-Captured 2026-04-20 against wintty `windows@30482d8` (CI mode, ~30% GHA-equivalent variance expected). Schema version 2.
+Captured 2026-04-21 against wintty `windows@30482d8` (CI mode, ~30% GHA-equivalent variance expected). Schema version 2.
 
 | Cell | Shell | Workload | Fixture size | p50 throughput |
 |------|------------------|--------------------------|--------------|----------------|
-| C1   | pwsh-7.4         | vtebench dense_cells     | 2.57 MB      | pending re-run |
-| C2   | pwsh-7.4         | vtebench scrolling       | 200 KB       | pending re-run |
+| C1   | pwsh-7.4         | vtebench dense_cells     | 2.57 MB      | 870,751 B/s    |
+| C2   | pwsh-7.4         | vtebench scrolling       | 200 KB       | degraded       |
 | C3   | pwsh-7.4         | cjk_jp_mixed_1mb         | 1 MB         | 128,520 B/s    |
-| C4   | wsl-ubuntu-24.04 | vtebench dense_cells     | 2.57 MB      | pending re-run |
-| C5   | wsl-ubuntu-24.04 | vtebench unicode         | 138 KB       | pending re-run |
+| C4   | wsl-ubuntu-24.04 | vtebench dense_cells     | 2.57 MB      | 998,836 B/s    |
+| C5   | wsl-ubuntu-24.04 | vtebench unicode         | 138 KB       | 67,190 B/s     |
 | C10  | wsl-ubuntu-24.04 | vtebench_cat_sustained   | 1 MB         | 23,142 B/s     |
 | C11  | wsl-ubuntu-24.04 | filtered_random_sustained| 1 MB         | 59,103 B/s     |
 
-C1, C2, C4, C5 fixtures were replaced from upstream shell-script wrappers to the actual byte streams vtebench produces; p50 re-runs land in a follow-up. C3, C10, C11 are current steady-state signal. Generators for all vtebench fixtures live in `scripts/fixtures/make-vtebench-fixtures.sh`; generators for C10 and C11 live in `scripts/fixtures/make-c1{0,1}.sh` and cache under `$HOME/.cache/wintty-bench/` on WSL with a content-hashed sidecar.
+C1, C2, C4, C5 fixtures were replaced from upstream shell-script wrappers to the actual byte streams vtebench produces; the numbers above are the fresh re-run. C3, C10, C11 are current steady-state signal. Generators for all vtebench fixtures live in `scripts/fixtures/make-vtebench-fixtures.sh`; generators for C10 and C11 live in `scripts/fixtures/make-c1{0,1}.sh` and cache under `$HOME/.cache/wintty-bench/` on WSL with a content-hashed sidecar.
+
+C2 lands as `degraded` (schema v2 `source=degraded`, nullable p50) because 5 of 9 measured iterations exceeded the 2-minute per-iteration shell timeout. The 4 completing iterations landed at ~1,700 B/s, consistent with pwsh `Get-Content -Raw | Write-Host` streaming 100,001 short lines. Investigating whether this is a Wintty scroll-path cost or a pwsh `Write-Host` cost is a separate workstream.
 
 Marketing-grade numbers coming in a later plan.
 


### PR DESCRIPTION
## Summary

Follow-up to # 1. Ran the CI bench against the fixed byte-stream fixtures on wintty `windows@30482d8` and replaced the `pending re-run` placeholders in the README baseline table with fresh numbers.

| Cell | Workload            | Before (wrapper) | After (real fixture) |
|------|---------------------|------------------|----------------------|
| C1   | dense_cells (pwsh)  | 222 B/s          | 870,751 B/s          |
| C2   | scrolling (pwsh)    | 24 B/s           | degraded             |
| C4   | dense_cells (WSL)   | 307 B/s          | 998,836 B/s          |
| C5   | unicode (WSL)       | 33 B/s           | 67,190 B/s           |

C1/C4/C5 jumped ~3,900x/3,250x/2,000x once the workload actually streamed the bytes vtebench produces instead of the 70-85 byte shell wrappers.

## C2 is degraded

5 of 9 measured iterations exceeded the harness's 2-minute per-iteration shell timeout, so the schema-v2 degraded path kicks in and `value_p50` is null. The 4 completers ran ~1,700 B/s, consistent with pwsh `Get-Content -Raw | Write-Host` streaming 100,001 short lines. Whether that ceiling is a Wintty scroll-path cost or a pwsh `Write-Host` cost is a separate workstream.

## Test plan

- [x] CI bench run: `results/ci/20260421T060027Z-1.0.0_3/{C1,C2,C4,C5}.json`
- [x] `rg 'pending re-run' README.md` -> no hits
- [x] Table stays schema-consistent with C3/C10/C11