### PR TITLE
refactor(cells): split C2 scrolling into C2a (pwsh) + C2b (wsl)

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,16 +15,17 @@ Captured 2026-04-21 against wintty `windows@30482d8` (CI mode, ~30% GHA-equivale
 | Cell | Shell | Workload | Fixture size | p50 throughput |
 |------|------------------|--------------------------|--------------|----------------|
 | C1   | pwsh-7.4         | vtebench dense_cells     | 2.57 MB      | 870,751 B/s    |
-| C2   | pwsh-7.4         | vtebench scrolling       | 200 KB       | degraded       |
+| C2a  | pwsh-7.4         | vtebench scrolling       | 200 KB       | 2,104 B/s      |
+| C2b  | wsl-ubuntu-24.04 | vtebench scrolling       | 200 KB       | 96,841 B/s     |
 | C3   | pwsh-7.4         | cjk_jp_mixed_1mb         | 1 MB         | 128,520 B/s    |
 | C4   | wsl-ubuntu-24.04 | vtebench dense_cells     | 2.57 MB      | 998,836 B/s    |
 | C5   | wsl-ubuntu-24.04 | vtebench unicode         | 138 KB       | 67,190 B/s     |
 | C10  | wsl-ubuntu-24.04 | vtebench_cat_sustained   | 1 MB         | 23,142 B/s     |
 | C11  | wsl-ubuntu-24.04 | filtered_random_sustained| 1 MB         | 59,103 B/s     |
 
-C1, C2, C4, C5 fixtures were replaced from upstream shell-script wrappers to the actual byte streams vtebench produces; the numbers above are the fresh re-run. C3, C10, C11 are current steady-state signal. Generators for all vtebench fixtures live in `scripts/fixtures/make-vtebench-fixtures.sh`; generators for C10 and C11 live in `scripts/fixtures/make-c1{0,1}.sh` and cache under `$HOME/.cache/wintty-bench/` on WSL with a content-hashed sidecar.
+C1, C2a, C2b, C4, C5 fixtures were replaced from upstream shell-script wrappers to the actual byte streams vtebench produces; the numbers above are the fresh re-run. C3, C10, C11 are current steady-state signal. Generators for all vtebench fixtures live in `scripts/fixtures/make-vtebench-fixtures.sh`; generators for C10 and C11 live in `scripts/fixtures/make-c1{0,1}.sh` and cache under `$HOME/.cache/wintty-bench/` on WSL with a content-hashed sidecar.
 
-C2 lands as `degraded` (schema v2 `source=degraded`, nullable p50) because 5 of 9 measured iterations exceeded the 2-minute per-iteration shell timeout. The 4 completing iterations landed at ~1,700 B/s, consistent with pwsh `Get-Content -Raw | Write-Host` streaming 100,001 short lines. Investigating whether this is a Wintty scroll-path cost or a pwsh `Write-Host` cost is a separate workstream.
+C2 was split into C2a (pwsh) and C2b (wsl) after a 2026-04-21 probe: the same 200 KB `y\n` scroll fixture hits ~2k B/s through pwsh-on-ConPTY and ~97k B/s through WSL `cat` on the same Wintty binary. The ~50x gap is the user-shell floor (three pwsh writer APIs -- `Write-Host`, `[Console]::Out.Write`, `Out-Host` -- all landed within ~8%), not a Wintty scroll-path cost.
 
 Marketing-grade numbers coming in a later plan.
 

--- a/README.md
+++ b/README.md
@@ -15,15 +15,17 @@ Captured 2026-04-21 against wintty `windows@30482d8` (CI mode, ~30% GHA-equivale
 | Cell | Shell | Workload | Fixture size | p50 throughput |
 |------|------------------|--------------------------|--------------|----------------|
 | C1   | pwsh-7.4         | vtebench dense_cells     | 2.57 MB      | 870,751 B/s    |
-| C2a  | pwsh-7.4         | vtebench scrolling       | 200 KB       | 2,104 B/s      |
-| C2b  | wsl-ubuntu-24.04 | vtebench scrolling       | 200 KB       | 96,841 B/s     |
+| C2a  | pwsh-7.4         | vtebench scrolling       | 200 KB       | ~2,104 B/s *   |
+| C2b  | wsl-ubuntu-24.04 | vtebench scrolling       | 200 KB       | ~96,841 B/s *  |
 | C3   | pwsh-7.4         | cjk_jp_mixed_1mb         | 1 MB         | 128,520 B/s    |
 | C4   | wsl-ubuntu-24.04 | vtebench dense_cells     | 2.57 MB      | 998,836 B/s    |
 | C5   | wsl-ubuntu-24.04 | vtebench unicode         | 138 KB       | 67,190 B/s     |
 | C10  | wsl-ubuntu-24.04 | vtebench_cat_sustained   | 1 MB         | 23,142 B/s     |
 | C11  | wsl-ubuntu-24.04 | filtered_random_sustained| 1 MB         | 59,103 B/s     |
 
-C1, C2a, C2b, C4, C5 fixtures were replaced from upstream shell-script wrappers to the actual byte streams vtebench produces; the numbers above are the fresh re-run. C3, C10, C11 are current steady-state signal. Generators for all vtebench fixtures live in `scripts/fixtures/make-vtebench-fixtures.sh`; generators for C10 and C11 live in `scripts/fixtures/make-c1{0,1}.sh` and cache under `$HOME/.cache/wintty-bench/` on WSL with a content-hashed sidecar.
+\* C2a and C2b numbers are from the 2026-04-21 scrolling-degradation probe (4-iteration writer-variant harness), not a fresh 9-iteration full-harness run under the new IDs. Full-harness re-run pending.
+
+C1, C4, C5 fixtures were replaced from upstream shell-script wrappers to the actual byte streams vtebench produces; the numbers above are the fresh re-run. C3, C10, C11 are current steady-state signal. Generators for all vtebench fixtures live in `scripts/fixtures/make-vtebench-fixtures.sh`; generators for C10 and C11 live in `scripts/fixtures/make-c1{0,1}.sh` and cache under `$HOME/.cache/wintty-bench/` on WSL with a content-hashed sidecar.
 
 C2 was split into C2a (pwsh) and C2b (wsl) after a 2026-04-21 probe: the same 200 KB `y\n` scroll fixture hits ~2k B/s through pwsh-on-ConPTY and ~97k B/s through WSL `cat` on the same Wintty binary. The ~50x gap is the user-shell floor (three pwsh writer APIs -- `Write-Host`, `[Console]::Out.Write`, `Out-Host` -- all landed within ~8%), not a Wintty scroll-path cost.
 

--- a/harness.tests/BenchHostArgsTests.cs
+++ b/harness.tests/BenchHostArgsTests.cs
@@ -28,7 +28,8 @@ public class BenchHostArgsTests
         var parsed = BenchHost.ParseArgs(args);
 
         Assert.Contains("C1", parsed.Cells);
-        Assert.Contains("C2", parsed.Cells);
+        Assert.Contains("C2a", parsed.Cells);
+        Assert.Contains("C2b", parsed.Cells);
         Assert.Contains("C3", parsed.Cells);
         Assert.Contains("C4", parsed.Cells);
     }

--- a/harness.tests/CellTests.cs
+++ b/harness.tests/CellTests.cs
@@ -7,10 +7,10 @@ namespace WinttyBench.Tests;
 public class CellTests
 {
     [Fact]
-    public void StarredCells_Contains_Seven_After_C10_C11_Added()
+    public void StarredCells_Contains_Eight_After_C2_Split()
     {
         var all = StarredCells.All;
-        Assert.Equal(7, all.Count);
+        Assert.Equal(8, all.Count);
         Assert.Contains(all, c => c.Id == "C10");
         Assert.Contains(all, c => c.Id == "C11");
     }
@@ -39,15 +39,27 @@ public class CellTests
     }
 
     [Fact]
-    public void C2_Targets_Pwsh_Vtebench_Scrolling_Throughput()
+    public void C2a_Targets_Pwsh_Vtebench_Scrolling_Throughput()
     {
-        var c2 = StarredCells.All.Single(c => c.Id == "C2");
+        var c2a = StarredCells.All.Single(c => c.Id == "C2a");
 
-        Assert.Equal("pwsh-7.4", c2.Shell);
-        Assert.Equal("vtebench_scrolling", c2.Workload);
-        Assert.Equal("throughput_bytes_per_sec", c2.Kpi);
-        Assert.Equal("fixtures/vtebench/scrolling.txt", c2.FixturePath);
-        Assert.Null(c2.FixtureKey);
+        Assert.Equal("pwsh-7.4", c2a.Shell);
+        Assert.Equal("vtebench_scrolling", c2a.Workload);
+        Assert.Equal("throughput_bytes_per_sec", c2a.Kpi);
+        Assert.Equal("fixtures/vtebench/scrolling.txt", c2a.FixturePath);
+        Assert.Null(c2a.FixtureKey);
+    }
+
+    [Fact]
+    public void C2b_Targets_Wsl_Vtebench_Scrolling_Throughput()
+    {
+        var c2b = StarredCells.All.Single(c => c.Id == "C2b");
+
+        Assert.Equal("wsl-ubuntu-24.04", c2b.Shell);
+        Assert.Equal("vtebench_scrolling", c2b.Workload);
+        Assert.Equal("throughput_bytes_per_sec", c2b.Kpi);
+        Assert.Equal("fixtures/vtebench/scrolling.txt", c2b.FixturePath);
+        Assert.Null(c2b.FixtureKey);
     }
 
     [Fact]

--- a/harness.tests/CellTests.cs
+++ b/harness.tests/CellTests.cs
@@ -7,10 +7,16 @@ namespace WinttyBench.Tests;
 public class CellTests
 {
     [Fact]
-    public void StarredCells_Contains_Eight_After_C2_Split()
+    public void StarredCells_All_Ids_Are_Unique()
     {
+        // BenchHost dispatches per cell via Single(c => c.Id == ...); a
+        // duplicate Id silently breaks lookup. Pin the uniqueness invariant
+        // rather than the cell count, so additive splits (future C3a/C3b
+        // etc.) don't require touching this test.
         var all = StarredCells.All;
-        Assert.Equal(8, all.Count);
+        Assert.Equal(all.Count, all.Select(c => c.Id).Distinct().Count());
+        Assert.Contains(all, c => c.Id == "C2a");
+        Assert.Contains(all, c => c.Id == "C2b");
         Assert.Contains(all, c => c.Id == "C10");
         Assert.Contains(all, c => c.Id == "C11");
     }

--- a/harness/Cells/StarredCells.cs
+++ b/harness/Cells/StarredCells.cs
@@ -18,11 +18,9 @@ public static class StarredCells
             FixtureKey: null,
             WinttyConfigOverrides: Empty),
 
-        // C2 split into C2a (pwsh) + C2b (wsl) after the 2026-04-21
-        // scrolling-degradation investigation. Same fixture through both
-        // shells hits ~2k B/s on pwsh-on-ConPTY and ~97k B/s on WSL `cat`
-        // on the same Wintty binary -- the ~50x gap is the user-shell floor,
-        // not a Wintty scroll-path cost.
+        // C2 is split into C2a (pwsh, ~2k B/s user-shell floor) and C2b
+        // (wsl `cat`, ~97k B/s fast path) on the same fixture and binary;
+        // the ~50x gap is the pwsh+ConPTY ceiling, not a wintty cost.
         new Cell(
             Id: "C2a",
             Shell: "pwsh-7.4",

--- a/harness/Cells/StarredCells.cs
+++ b/harness/Cells/StarredCells.cs
@@ -18,9 +18,23 @@ public static class StarredCells
             FixtureKey: null,
             WinttyConfigOverrides: Empty),
 
+        // C2 split into C2a (pwsh) + C2b (wsl) after the 2026-04-21
+        // scrolling-degradation investigation. Same fixture through both
+        // shells hits ~2k B/s on pwsh-on-ConPTY and ~97k B/s on WSL `cat`
+        // on the same Wintty binary -- the ~50x gap is the user-shell floor,
+        // not a Wintty scroll-path cost.
         new Cell(
-            Id: "C2",
+            Id: "C2a",
             Shell: "pwsh-7.4",
+            Workload: "vtebench_scrolling",
+            Kpi: "throughput_bytes_per_sec",
+            FixturePath: "fixtures/vtebench/scrolling.txt",
+            FixtureKey: null,
+            WinttyConfigOverrides: Empty),
+
+        new Cell(
+            Id: "C2b",
+            Shell: "wsl-ubuntu-24.04",
             Workload: "vtebench_scrolling",
             Kpi: "throughput_bytes_per_sec",
             FixturePath: "fixtures/vtebench/scrolling.txt",


### PR DESCRIPTION
## Why

C2 previously landed as `degraded` in the Plan 2A baseline because pwsh on ConPTY pushed 5/9 measured iterations over the 120s per-iteration timeout on the 200 KB `y\n` scrolling fixture. A separate 2026-04-21 probe swapped the writer API three times on the same Wintty binary:

| Writer | p50 | p95 |
|--------|-----|-----|
| pwsh `Get-Content \| Write-Host -NoNewline` | 2,104 B/s | 2,319 B/s |
| pwsh `[Console]::Out.Write((Get-Content))` | 2,237 B/s | 2,295 B/s |
| pwsh `Get-Content \| Out-Host` | 2,287 B/s | 2,327 B/s |
| WSL `cat` | 96,841 B/s | 101,548 B/s |

All three pwsh writer APIs sit within ~8% of each other. WSL `cat` is ~46x faster on the same binary. The bottleneck is below the writer API (pwsh runtime + per-line ConPTY round-trip), not the scroll path inside Wintty, and not `Write-Host` specifically.

## What

- Replace the single `C2` entry in `StarredCells` with `C2a` (pwsh-7.4) and `C2b` (wsl-ubuntu-24.04), both pointing at the same `fixtures/vtebench/scrolling.txt`.
- Update README baseline table: drop the `degraded` marker on the pwsh row (~2k B/s is the real floor, not a timeout artefact) and add the WSL row. Replace the "C2 lands as degraded" paragraph with a one-line footnote on the pwsh/WSL asymmetry.
- Rename + duplicate the two tests that pinned `C2` (`CellTests.C2_Targets_*`, `BenchHostArgsTests.Parse_All_Cells_Expands_To_Starred`). Bump the cell count assertion from 7 to 8.

No `MeasurementRunner` / `BenchHost` changes: the existing dispatch on `Cell.Shell` already handles both shells.

## Test plan

- [x] `dotnet build` clean (0 warnings, 0 errors)
- [x] `dotnet run --project harness.tests` -> 60 total, 59 passed, 1 skipped (smoke test requires built wintty target)
- [ ] Reviewer eyeball on the README asymmetry footnote