### PR TITLE
docs: 9-iter rebaseline for C2a/C2b cells

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,15 +15,13 @@ Captured 2026-04-21 against wintty `windows@30482d8` (CI mode, ~30% GHA-equivale
 | Cell | Shell | Workload | Fixture size | p50 throughput |
 |------|------------------|--------------------------|--------------|----------------|
 | C1   | pwsh-7.4         | vtebench dense_cells     | 2.57 MB      | 870,751 B/s    |
-| C2a  | pwsh-7.4         | vtebench scrolling       | 200 KB       | ~2,104 B/s *   |
-| C2b  | wsl-ubuntu-24.04 | vtebench scrolling       | 200 KB       | ~96,841 B/s *  |
+| C2a  | pwsh-7.4         | vtebench scrolling       | 200 KB       | 1,733 B/s      |
+| C2b  | wsl-ubuntu-24.04 | vtebench scrolling       | 200 KB       | 73,384 B/s     |
 | C3   | pwsh-7.4         | cjk_jp_mixed_1mb         | 1 MB         | 128,520 B/s    |
 | C4   | wsl-ubuntu-24.04 | vtebench dense_cells     | 2.57 MB      | 998,836 B/s    |
 | C5   | wsl-ubuntu-24.04 | vtebench unicode         | 138 KB       | 67,190 B/s     |
 | C10  | wsl-ubuntu-24.04 | vtebench_cat_sustained   | 1 MB         | 23,142 B/s     |
 | C11  | wsl-ubuntu-24.04 | filtered_random_sustained| 1 MB         | 59,103 B/s     |
-
-\* C2a and C2b numbers are from the 2026-04-21 scrolling-degradation probe (4-iteration writer-variant harness), not a fresh 9-iteration full-harness run under the new IDs. Full-harness re-run pending.
 
 C1, C4, C5 fixtures were replaced from upstream shell-script wrappers to the actual byte streams vtebench produces; the numbers above are the fresh re-run. C3, C10, C11 are current steady-state signal. Generators for all vtebench fixtures live in `scripts/fixtures/make-vtebench-fixtures.sh`; generators for C10 and C11 live in `scripts/fixtures/make-c1{0,1}.sh` and cache under `$HOME/.cache/wintty-bench/` on WSL with a content-hashed sidecar.
 


### PR DESCRIPTION
Replaces the 4-iteration writer-variant probe numbers in the cells table with fresh 9-iteration --mode=ci values from the standard MeasurementRunner. Drops the * footnote that flagged the prior numbers as a probe.

Cells unchanged. Fixture unchanged. Wintty binary reused from the PR # 9 smoke (origin/windows@da77dd2, 2026-04-28).

| Cell | Old (4-iter probe) | New (9-iter CI) |
|------|--------------------|-----------------|
| C2a  | ~2,104 B/s         | 1,733 B/s       |
| C2b  | ~96,841 B/s        | 73,384 B/s      |

The C2 split explanation paragraph (pwsh-on-ConPTY ceiling vs WSL fast path) stays as-is.