### PR TITLE
fix(envprobe): degrade gracefully when wintty target is empty

### DIFF
--- a/harness.tests/EnvProbeTests.cs
+++ b/harness.tests/EnvProbeTests.cs
@@ -1,0 +1,23 @@
+using WinttyBench;
+using Xunit;
+
+namespace WinttyBench.Tests;
+
+public class EnvProbeTests
+{
+    [Fact]
+    public void Capture_DegradesToUnknown_WhenWinttyTargetIsEmpty()
+    {
+        // BenchHost passes string.Empty to EnvProbe.Capture when no wintty
+        // target is configured (e.g. --terminals=wt only). EnvProbe.Capture
+        // is documented to silently degrade to "unknown" in that case; this
+        // pin keeps the documented contract from drifting -- without the
+        // empty-path guard, FileVersionInfo.GetVersionInfo("") throws
+        // ArgumentException and the top catch in BenchHost reports it as
+        // "Arg error: ...", masking the real source.
+        var env = EnvProbe.Capture(string.Empty);
+
+        Assert.Equal("unknown", env.WinttySha);
+        Assert.Equal("unknown", env.WinttyVersion);
+    }
+}

--- a/harness/EnvProbe.cs
+++ b/harness/EnvProbe.cs
@@ -28,6 +28,13 @@ public static class EnvProbe
 
     private static (string sha, string version) ProbeWinttyVersion(string exePath)
     {
+        // Empty path -- caller passed string.Empty when wintty is not in --terminals.
+        // Match the documented "silently degrades to unknown" contract; without this
+        // FileVersionInfo.GetVersionInfo("") throws ArgumentException, which the top
+        // catch reports as an "Arg error:" and masks the real source.
+        if (string.IsNullOrEmpty(exePath))
+            return ("unknown", "unknown");
+
         try
         {
 #pragma warning disable CA1416 // FileVersionInfo is cross-plat but some props are Windows-flavored; this harness is Windows-only.

--- a/harness/EnvProbe.cs
+++ b/harness/EnvProbe.cs
@@ -50,6 +50,15 @@ public static class EnvProbe
         {
             return ("unknown", "unknown");
         }
+        catch (ArgumentException)
+        {
+            // FileVersionInfo.GetVersionInfo also throws ArgumentException on
+            // structurally invalid paths (e.g. embedded \0, illegal chars).
+            // The empty-path case is handled by the early-return above; this
+            // catch keeps the "silently degrade" contract robust against any
+            // future caller that passes a malformed but non-empty string.
+            return ("unknown", "unknown");
+        }
     }
 
     private static string ProbeWtVersion()


### PR DESCRIPTION
## Why

Running the harness with `--terminals=wt --target-wt=auto` (no `--target` because no wintty in play) crashed with:

    Arg error: The path is empty. (Parameter 'path')

`BenchHost` passes `string.Empty` to `EnvProbe.Capture` when no wintty target is configured, and the `Capture` comment promises that `ProbeWinttyVersion` "silently degrades to unknown" in that case. But the implementation only catches `FileNotFoundException` and `IOException`, while `FileVersionInfo.GetVersionInfo("")` throws `ArgumentException`, which bubbles all the way to the top catch and gets reported as an "Arg error:" -- masking the real source.

## What

One-line guard at the top of `ProbeWinttyVersion` to honor the documented contract for the empty-path case.

## Verification

`dotnet run --project harness -- --mode=ci --cells=C5 --terminals=wt --target-wt=auto` now runs to completion and writes `results/ci/<runId>/C5-wt.json` with `wintty_sha = "unknown"` / `wintty_version = "unknown"`, as expected. (The hung iterations in that output are a separate WT-launcher issue tracked alongside this fix.)