### PR TITLE
fix(wt-launcher): use settings fragment with stable source dir

### DIFF
--- a/harness.tests/LauncherTests.cs
+++ b/harness.tests/LauncherTests.cs
@@ -48,31 +48,6 @@ public class LauncherTests
         Assert.Equal("WindowsTerminal", launcher.ExpectedProcessName);
     }
 
-    [Fact]
-    public void WtLauncher_Env_Sets_WT_SETTINGS_PATH()
-    {
-        var tempRoot = "C:\\temp\\wt-bench-x";
-        var env = WtLauncher.BuildEnv(tempRoot);
-
-        Assert.Equal(tempRoot, env["WT_SETTINGS_PATH"]);
-    }
-
-    [Fact]
-    public void WtLauncher_WritesSettingsJson_WithShellCommand()
-    {
-        var tempRoot = Path.Combine(Path.GetTempPath(), "wt-bench-test-" + Guid.NewGuid());
-        try
-        {
-            WtLauncher.WriteSettings(tempRoot, shellCommand: "pwsh -NoLogo", cols: 80, rows: 24);
-            var settingsPath = Path.Combine(tempRoot, "settings.json");
-            Assert.True(File.Exists(settingsPath));
-            var content = File.ReadAllText(settingsPath);
-            Assert.Contains("\"commandline\"", content);
-            Assert.Contains("pwsh -NoLogo", content);
-        }
-        finally
-        {
-            if (Directory.Exists(tempRoot)) Directory.Delete(tempRoot, recursive: true);
-        }
-    }
+    // WT settings handoff tests live in Launchers/WtLauncherTests.cs alongside
+    // the rest of the WtLauncher coverage.
 }

--- a/harness.tests/Launchers/WtLauncherTests.cs
+++ b/harness.tests/Launchers/WtLauncherTests.cs
@@ -9,18 +9,22 @@ namespace WinttyBench.Tests.Launchers;
 public class WtLauncherTests
 {
     [Fact]
-    public void WriteSettings_PinsInitialColsRowsAndCloseOnExit()
+    public void WriteFragment_PinsInitialColsRowsAndCloseOnExit()
     {
         var dir = Path.Combine(Path.GetTempPath(), "wt-launcher-test-" + System.Guid.NewGuid());
         try
         {
-            WtLauncher.WriteSettings(dir, "pwsh -NoLogo", cols: 120, rows: 32);
+            WtLauncher.WriteFragment(dir, "pwsh -NoLogo", cols: 120, rows: 32);
 
-            var settingsPath = Path.Combine(dir, "settings.json");
-            Assert.True(File.Exists(settingsPath));
+            // Filename matches the dir's leaf name (see WriteFragment comment).
+            var fragmentName = Path.GetFileName(dir);
+            var fragmentPath = Path.Combine(dir, fragmentName + ".json");
+            Assert.True(File.Exists(fragmentPath));
 
-            using var doc = JsonDocument.Parse(File.ReadAllText(settingsPath));
-            var profile = doc.RootElement.GetProperty("profiles").GetProperty("list")[0];
+            using var doc = JsonDocument.Parse(File.ReadAllText(fragmentPath));
+            // Top-level "profiles" is an array in the fragment shape -- not
+            // nested under "list" the way the main settings.json schema is.
+            var profile = doc.RootElement.GetProperty("profiles")[0];
 
             Assert.Equal("pwsh -NoLogo", profile.GetProperty("commandline").GetString());
             Assert.Equal(120, profile.GetProperty("initialCols").GetInt32());
@@ -28,8 +32,8 @@ public class WtLauncherTests
             Assert.Equal("always", profile.GetProperty("closeOnExit").GetString());
             Assert.Equal("WinttyBenchProfile", profile.GetProperty("name").GetString());
 
-            var defaultProfile = doc.RootElement.GetProperty("defaultProfile").GetString();
-            Assert.Equal("WinttyBenchProfile", defaultProfile);
+            // Fragments cannot set defaultProfile; the bench selects via `-p`.
+            Assert.False(doc.RootElement.TryGetProperty("defaultProfile", out _));
         }
         finally
         {
@@ -38,17 +42,19 @@ public class WtLauncherTests
     }
 
     [Fact]
-    public void WriteSettings_EscapesEmbeddedQuotes()
+    public void WriteFragment_EscapesEmbeddedQuotes()
     {
         var dir = Path.Combine(Path.GetTempPath(), "wt-launcher-test-" + System.Guid.NewGuid());
         try
         {
-            WtLauncher.WriteSettings(dir, "bash -c \"echo hi\"", cols: 80, rows: 24);
-            var settingsPath = Path.Combine(dir, "settings.json");
-            var content = File.ReadAllText(settingsPath);
+            WtLauncher.WriteFragment(dir, "bash -c \"echo hi\"", cols: 80, rows: 24);
+
+            var fragmentName = Path.GetFileName(dir);
+            var fragmentPath = Path.Combine(dir, fragmentName + ".json");
+            var content = File.ReadAllText(fragmentPath);
             // The JSON must parse without error and the commandline must round-trip.
-            using var doc = System.Text.Json.JsonDocument.Parse(content);
-            var profile = doc.RootElement.GetProperty("profiles").GetProperty("list")[0];
+            using var doc = JsonDocument.Parse(content);
+            var profile = doc.RootElement.GetProperty("profiles")[0];
             Assert.Equal("bash -c \"echo hi\"", profile.GetProperty("commandline").GetString());
         }
         finally
@@ -58,11 +64,14 @@ public class WtLauncherTests
     }
 
     [Fact]
-    public void BuildEnv_SetsWtSettingsPath()
+    [SupportedOSPlatform("windows")]
+    public void GetFragmentRoot_PointsAtCanonicalLocalAppDataFragmentsDir()
     {
-        var env = WtLauncher.BuildEnv("C:/foo/bar");
-        Assert.Single(env);
-        Assert.Equal("C:/foo/bar", env["WT_SETTINGS_PATH"]);
+        var root = WtLauncher.GetFragmentRoot();
+        var expected = Path.Combine(
+            System.Environment.GetFolderPath(System.Environment.SpecialFolder.LocalApplicationData),
+            "Microsoft", "Windows Terminal", "Fragments");
+        Assert.Equal(expected, root);
     }
 
     [Fact]

--- a/harness.tests/Launchers/WtLauncherTests.cs
+++ b/harness.tests/Launchers/WtLauncherTests.cs
@@ -75,6 +75,63 @@ public class WtLauncherTests
     }
 
     [Fact]
+    public void WriteFragment_TrailingSlashOnDir_FilenameUsesLeafName()
+    {
+        // Locks down the leaf-name extraction in WriteFragment so a future
+        // refactor that drops the TrimEnd doesn't silently put the JSON at
+        // <dir>\.json (empty leaf), which WT would not load.
+        var bare = Path.Combine(Path.GetTempPath(), "wt-launcher-test-" + System.Guid.NewGuid());
+        var dirWithSlash = bare + Path.DirectorySeparatorChar;
+        try
+        {
+            WtLauncher.WriteFragment(dirWithSlash, "pwsh", cols: 80, rows: 24);
+            var leaf = Path.GetFileName(bare);
+            Assert.True(File.Exists(Path.Combine(bare, leaf + ".json")));
+        }
+        finally
+        {
+            if (Directory.Exists(bare)) Directory.Delete(bare, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void SweepLegacyFragments_DeletesHyphenSuffixedDirs_LeavesPlainDir()
+    {
+        // Pins the regex literal: pattern wintty-bench-* must match the
+        // legacy GUID-suffixed dirs and NOT the live "wintty-bench" stable
+        // dir. A future refactor that broadens the pattern would silently
+        // delete the live profile mid-run.
+        var fragRoot = Path.Combine(Path.GetTempPath(), "wt-sweep-test-" + System.Guid.NewGuid());
+        try
+        {
+            Directory.CreateDirectory(Path.Combine(fragRoot, "wintty-bench"));
+            Directory.CreateDirectory(Path.Combine(fragRoot, "wintty-bench-abc123"));
+            Directory.CreateDirectory(Path.Combine(fragRoot, "wintty-bench-def456"));
+            Directory.CreateDirectory(Path.Combine(fragRoot, "Microsoft.WSL"));
+
+            WtLauncher.SweepLegacyFragments(fragRoot);
+
+            Assert.True(Directory.Exists(Path.Combine(fragRoot, "wintty-bench")), "stable dir must survive sweep");
+            Assert.False(Directory.Exists(Path.Combine(fragRoot, "wintty-bench-abc123")), "legacy dir must be swept");
+            Assert.False(Directory.Exists(Path.Combine(fragRoot, "wintty-bench-def456")), "legacy dir must be swept");
+            Assert.True(Directory.Exists(Path.Combine(fragRoot, "Microsoft.WSL")), "unrelated dirs must survive");
+        }
+        finally
+        {
+            if (Directory.Exists(fragRoot)) Directory.Delete(fragRoot, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void SweepLegacyFragments_NoFragmentRoot_NoThrow()
+    {
+        // Pins the !Directory.Exists short-circuit: callers (Launch) invoke
+        // sweep before any iter has a chance to create the Fragments root.
+        WtLauncher.SweepLegacyFragments(Path.Combine(Path.GetTempPath(),
+            "wt-sweep-nonexistent-" + System.Guid.NewGuid()));
+    }
+
+    [Fact]
     [SupportedOSPlatform("windows")]
     public void WtClassName_MatchesCascadiaHostingWindowClass()
     {

--- a/harness/Launchers/ILauncher.cs
+++ b/harness/Launchers/ILauncher.cs
@@ -20,6 +20,14 @@ public sealed class LaunchHandle : IDisposable
     public required MeasurableProcess Process { get; init; }
     public required string ConfigRoot { get; init; }
 
+    // When true, Dispose leaves ConfigRoot intact. WtLauncher uses a
+    // stable shared fragment dir under %LOCALAPPDATA%\Microsoft\Windows
+    // Terminal\Fragments\wintty-bench\ that's reused across iterations;
+    // recursively deleting it between iters would defeat the stable-source
+    // invariant the comments in WtLauncher.Launch defend. Per-launch temp
+    // dirs (the Wintty launcher) keep the default false.
+    public bool KeepConfigRoot { get; init; }
+
     // Optional JobObject that contains Process and all its descendants.
     // When set, disposing it is the canonical kill path: CloseHandle with
     // KILL_ON_JOB_CLOSE reaps everything in one shot, even descendants that
@@ -42,6 +50,7 @@ public sealed class LaunchHandle : IDisposable
         // a no-op (already gone) or a belt-and-braces fallback.
         Job?.Dispose();
         Process.Kill();
+        if (KeepConfigRoot) return;
         try
         {
             if (Directory.Exists(ConfigRoot)) Directory.Delete(ConfigRoot, recursive: true);

--- a/harness/Launchers/WtLauncher.cs
+++ b/harness/Launchers/WtLauncher.cs
@@ -11,6 +11,11 @@ public sealed class WtLauncher : ILauncher
     // Timing wt.exe would miss the actual window startup.
     public string ExpectedProcessName => "WindowsTerminal";
 
+    // Single source of truth for the profile name used in the fragment JSON
+    // and the `-p` CLI argument. Lifted to a const so the two sites can't
+    // drift independently.
+    private const string ProfileName = "WinttyBenchProfile";
+
     public LaunchHandle Launch(LaunchRequest request)
     {
         ArgumentNullException.ThrowIfNull(request);
@@ -37,7 +42,7 @@ public sealed class WtLauncher : ILauncher
         var startInfo = new ProcessStartInfo
         {
             FileName = request.TargetExePath,
-            Arguments = "-p WinttyBenchProfile",
+            Arguments = "-p " + ProfileName,
             UseShellExecute = false,
         };
 
@@ -60,7 +65,19 @@ public sealed class WtLauncher : ILauncher
             ? WtHwndLocator.SnapshotCascadiaPids()
             : new HashSet<int>();
 
-        Process.Start(startInfo);
+        // Surface a structured failure if wt.exe can't even start (missing,
+        // quarantined, ACL-denied) instead of letting the raw Win32Exception
+        // bubble through LatencyRunner / ThroughputRunner.
+        try
+        {
+            Process.Start(startInfo);
+        }
+        catch (System.ComponentModel.Win32Exception ex)
+        {
+            throw new InvalidOperationException(
+                string.Create(CultureInfo.InvariantCulture,
+                    $"Failed to start wt.exe at '{request.TargetExePath}'"), ex);
+        }
 
         // Poll for the NEW WT host: a CASCADIA window whose owning PID
         // is not in the pre-spawn snapshot. The HWND identifies the
@@ -129,6 +146,9 @@ public sealed class WtLauncher : ILauncher
         {
             Process = measurable,
             ConfigRoot = fragmentDir,
+            // Stable shared dir, reused across iters -- see field comment
+            // and the Launch-method block above.
+            KeepConfigRoot = true,
             WindowHandle = hwnd != 0 ? hwnd : null,
             Job = job,
         };
@@ -151,24 +171,41 @@ public sealed class WtLauncher : ILauncher
         // Interlocked guard so concurrent first-launches in the same process
         // only sweep once. The bench is single-threaded today, but the static
         // is defense-in-depth for future parallel callers.
-        //
-        // Pattern wintty-bench-* (with trailing hyphen) targets only the
-        // legacy GUID-suffixed dirs from an earlier broken iteration; the
-        // current stable dir is plain "wintty-bench" (no hyphen) so it's
-        // not matched.
         if (Interlocked.Exchange(ref s_swept, 1) != 0) return;
+        SweepLegacyFragments(fragmentRoot);
+    }
+
+    // Internal for tests (no once-guard, invoked directly).
+    //
+    // Pattern wintty-bench-* (with trailing hyphen) targets only the
+    // legacy GUID-suffixed dirs from an earlier broken iteration; the
+    // current stable dir is plain "wintty-bench" (no hyphen) so it's
+    // not matched. Broadening the pattern to "wintty-bench*" would
+    // erroneously delete the live profile dir mid-run.
+    internal static void SweepLegacyFragments(string fragmentRoot)
+    {
         try
         {
             if (!Directory.Exists(fragmentRoot)) return;
             foreach (var d in Directory.EnumerateDirectories(fragmentRoot, "wintty-bench-*"))
             {
                 try { Directory.Delete(d, recursive: true); }
-                catch (IOException) { /* best effort */ }
-                catch (UnauthorizedAccessException) { /* best effort */ }
+                catch (Exception ex) when (ex is IOException
+                    or UnauthorizedAccessException
+                    or DirectoryNotFoundException
+                    or System.Security.SecurityException)
+                {
+                    /* best effort */
+                }
             }
         }
-        catch (IOException) { /* best effort */ }
-        catch (UnauthorizedAccessException) { /* best effort */ }
+        catch (Exception ex) when (ex is IOException
+            or UnauthorizedAccessException
+            or DirectoryNotFoundException
+            or System.Security.SecurityException)
+        {
+            /* best effort */
+        }
     }
 
     public static void WriteFragment(string fragmentDir, string shellCommand, int cols, int rows)
@@ -196,7 +233,7 @@ public sealed class WtLauncher : ILauncher
 {
   "profiles": [
     {
-      "name": "WinttyBenchProfile",
+      "name": "{{ProfileName}}",
       "commandline": {{commandlineJson}},
       "initialCols": {{colsStr}},
       "initialRows": {{rowsStr}},
@@ -212,6 +249,13 @@ public sealed class WtLauncher : ILauncher
         // fragment is easy to attribute during debugging.
         var fragmentName = Path.GetFileName(fragmentDir
             .TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar));
-        File.WriteAllText(Path.Combine(fragmentDir, fragmentName + ".json"), json);
+        var finalPath = Path.Combine(fragmentDir, fragmentName + ".json");
+        // Atomic write: write to a sibling temp file then rename. WT's
+        // fragment watcher can fire on the file mid-flight; without this,
+        // a partial JSON would parse-fail and the fragment would silently
+        // drop until the next iter.
+        var tempPath = finalPath + ".tmp";
+        File.WriteAllText(tempPath, json);
+        File.Move(tempPath, finalPath, overwrite: true);
     }
 }

--- a/harness/Launchers/WtLauncher.cs
+++ b/harness/Launchers/WtLauncher.cs
@@ -14,8 +14,20 @@ public sealed class WtLauncher : ILauncher
     public LaunchHandle Launch(LaunchRequest request)
     {
         ArgumentNullException.ThrowIfNull(request);
-        var configRoot = Path.Combine(Path.GetTempPath(), "wt-bench-" + Guid.NewGuid());
-        WriteSettings(configRoot, request.ShellCommand, request.Cols, request.Rows);
+
+        // Stable fragment dir (NOT per-iter). WT auto-derives a profile
+        // GUID from (source, name); per-iter source dirs caused every
+        // iteration to register a NEW WinttyBenchProfile entry in the
+        // user's settings.json. Old entries persisted as orphans (empty
+        // commandline) and `wt -p WinttyBenchProfile` resolved to one of
+        // them, never to the freshly-written fragment. A single stable
+        // source means exactly one profile entry whose commandline gets
+        // overwritten each iter.
+        var fragmentRoot = GetFragmentRoot();
+        SweepLegacyFragmentsOnce(fragmentRoot);
+
+        var fragmentDir = Path.Combine(fragmentRoot, "wintty-bench");
+        WriteFragment(fragmentDir, request.ShellCommand, request.Cols, request.Rows);
 
         // Use request.TargetExePath, not "wt.exe" -- the latter resolves
         // via PATH to the Store-install wt.exe (App Execution Aliases),
@@ -28,12 +40,6 @@ public sealed class WtLauncher : ILauncher
             Arguments = "-p WinttyBenchProfile",
             UseShellExecute = false,
         };
-        // ProcessStartInfo.Environment is pre-populated with the parent's env;
-        // these entries override-or-add, they do not replace.
-        foreach (var (k, v) in BuildEnv(configRoot))
-        {
-            startInfo.Environment[k] = v;
-        }
 
         // Snapshot which CASCADIA-owning PIDs already exist before we
         // spawn. Reasons it must happen pre-spawn:
@@ -122,51 +128,90 @@ public sealed class WtLauncher : ILauncher
         return new LaunchHandle
         {
             Process = measurable,
-            ConfigRoot = configRoot,
+            ConfigRoot = fragmentDir,
             WindowHandle = hwnd != 0 ? hwnd : null,
             Job = job,
         };
     }
 
-    public static void WriteSettings(string settingsRoot, string shellCommand, int cols, int rows)
+    // Fragments root: %LOCALAPPDATA%\Microsoft\Windows Terminal\Fragments\.
+    // Empirically, both Store and unpackaged Windows Terminal load fragments
+    // from this canonical path. WT_SETTINGS_PATH is honored only by Store WT
+    // (and only for the main settings.json, not fragments), which is why an
+    // earlier WT_SETTINGS_PATH-based handoff silently fell through to the
+    // user's existing settings on portable WT.
+    public static string GetFragmentRoot() => Path.Combine(
+        Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+        "Microsoft", "Windows Terminal", "Fragments");
+
+    private static int s_swept;
+
+    private static void SweepLegacyFragmentsOnce(string fragmentRoot)
     {
-        Directory.CreateDirectory(settingsRoot);
-        // Numbers are formatted via InvariantCulture to keep settings.json
+        // Interlocked guard so concurrent first-launches in the same process
+        // only sweep once. The bench is single-threaded today, but the static
+        // is defense-in-depth for future parallel callers.
+        //
+        // Pattern wintty-bench-* (with trailing hyphen) targets only the
+        // legacy GUID-suffixed dirs from an earlier broken iteration; the
+        // current stable dir is plain "wintty-bench" (no hyphen) so it's
+        // not matched.
+        if (Interlocked.Exchange(ref s_swept, 1) != 0) return;
+        try
+        {
+            if (!Directory.Exists(fragmentRoot)) return;
+            foreach (var d in Directory.EnumerateDirectories(fragmentRoot, "wintty-bench-*"))
+            {
+                try { Directory.Delete(d, recursive: true); }
+                catch (IOException) { /* best effort */ }
+                catch (UnauthorizedAccessException) { /* best effort */ }
+            }
+        }
+        catch (IOException) { /* best effort */ }
+        catch (UnauthorizedAccessException) { /* best effort */ }
+    }
+
+    public static void WriteFragment(string fragmentDir, string shellCommand, int cols, int rows)
+    {
+        Directory.CreateDirectory(fragmentDir);
+        // Numbers formatted via InvariantCulture to keep the fragment JSON
         // locale-independent (CA1305). The interpolated handler would
-        // otherwise pick up CurrentCulture and produce e.g. "1 024" on
+        // otherwise pick up CurrentCulture and produce e.g. "1 024" on
         // some locales.
         var colsStr = cols.ToString(CultureInfo.InvariantCulture);
         var rowsStr = rows.ToString(CultureInfo.InvariantCulture);
         // JSON-encode shellCommand so internal " or \ don't malform the
-        // settings.json. JsonSerializer.Serialize on a string returns the
-        // value WITH surrounding quotes, e.g. "bash -c \"x\"" -- embed it
-        // raw into the template (no extra outer quotes). Use the source-
+        // fragment. JsonSerializer.Serialize on a string returns the value
+        // WITH surrounding quotes, e.g. "bash -c \"x\"" -- embed it raw
+        // into the template (no extra outer quotes). Use the source-
         // generated string TypeInfo for AOT/trim safety (IL2026/IL3050).
         var commandlineJson = System.Text.Json.JsonSerializer.Serialize(
             shellCommand, WinttyBench.ResultSchemaContext.Default.String);
+        // Fragment shape differs from settings.json: top-level "profiles"
+        // is an array, not nested under "list", and defaultProfile cannot
+        // be set from a fragment. The bench selects this profile explicitly
+        // via `wt -p WinttyBenchProfile`, so additive merge is sufficient
+        // and non-destructive to the user's existing WT settings.
         var json = $$"""
 {
-  "profiles": {
-    "list": [
-      {
-        "name": "WinttyBenchProfile",
-        "commandline": {{commandlineJson}},
-        "initialCols": {{colsStr}},
-        "initialRows": {{rowsStr}},
-        "closeOnExit": "always",
-        "hidden": false,
-        "startingDirectory": "%USERPROFILE%"
-      }
-    ]
-  },
-  "defaultProfile": "WinttyBenchProfile"
+  "profiles": [
+    {
+      "name": "WinttyBenchProfile",
+      "commandline": {{commandlineJson}},
+      "initialCols": {{colsStr}},
+      "initialRows": {{rowsStr}},
+      "closeOnExit": "always",
+      "hidden": false,
+      "startingDirectory": "%USERPROFILE%"
+    }
+  ]
 }
 """;
-        File.WriteAllText(Path.Combine(settingsRoot, "settings.json"), json);
+        // Filename inside the fragment dir is arbitrary; WT loads any
+        // *.json under Fragments\<source>\. Match the dir name so a stray
+        // fragment is easy to attribute during debugging.
+        var fragmentName = Path.GetFileName(fragmentDir
+            .TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar));
+        File.WriteAllText(Path.Combine(fragmentDir, fragmentName + ".json"), json);
     }
-
-    public static Dictionary<string, string> BuildEnv(string settingsRoot) => new()
-    {
-        ["WT_SETTINGS_PATH"] = settingsRoot,
-    };
 }


### PR DESCRIPTION
> **IMPORTANT:** stacked on # 14 (`fix/envprobe-empty-path`). GitHub auto-retargets this PR to `main` when # 14 merges.

## Why

`--terminals=wt` runs hung on every iteration because WT was loading the user's default settings instead of the bench's per-iter `settings.json`. Two compounding issues:

1. **Portable WT ignores `WT_SETTINGS_PATH`** -- it reads from `%LOCALAPPDATA%\Microsoft\Windows Terminal\settings.json` unconditionally. The `WT_SETTINGS_PATH`-based handoff fell through silently, so `wt -p WinttyBenchProfile` hit the user's default shell.

2. **Switching to a settings fragment with a per-iter source dir accumulated orphans.** WT derives a profile GUID from `(source, name)`; each iter registered a new `WinttyBenchProfile` entry in the user's `settings.json`. Prior entries persisted as orphans with empty `commandline` once their source dir was deleted, and `wt -p WinttyBenchProfile` resolved to one of them, never to the freshly-written fragment.

## What

- Switch handoff from `WT_SETTINGS_PATH` + `settings.json` to a settings fragment under `%LOCALAPPDATA%\Microsoft\Windows Terminal\Fragments\wintty-bench\`.
- Use a **stable** source dir name (not per-iter). One source = one profile entry, refreshed each iter, no orphan accumulation.
- Drop `BuildEnv` (it was a no-op).
- One-shot sweep on first launch removes legacy `wintty-bench-*` fragment dirs from prior crashed runs.
- Tests flipped to assert fragment shape (top-level `profiles` array, no `defaultProfile`) instead of `settings.json` shape.

## Verification

`dotnet run -- --mode=ci --cells=C5 --terminals=wt --target-wt=auto`:

- Before: 9/9 iters hung, p50 = degraded.
- After: 9/9 real values, p50 = ~903 kB/s. Settings.json grows by at most one stable `WinttyBenchProfile` entry, refreshed per run.

(The wide variance in `value_p95`/`p99` is the pre-existing throughput variance tracked by # 7, not introduced here.)