### PR TITLE
fix(throughput-runner): per-iter unique script path

### DIFF
--- a/harness.tests/Runners/ThroughputRunnerTests.cs
+++ b/harness.tests/Runners/ThroughputRunnerTests.cs
@@ -1,0 +1,93 @@
+using System.Collections.Frozen;
+using System.IO;
+using WinttyBench.Cells;
+using WinttyBench.Runners;
+using Xunit;
+
+namespace WinttyBench.Tests.Runners;
+
+public class ThroughputRunnerTests
+{
+    private static readonly Cell PwshCell = new(
+        Id: "TEST",
+        Shell: "pwsh-7.4",
+        Workload: "test_workload",
+        Kpi: "throughput_bytes_per_sec",
+        FixturePath: "fixtures/test.txt",
+        FixtureKey: null,
+        WinttyConfigOverrides: FrozenDictionary<string, string>.Empty);
+
+    private static readonly Cell WslCell = new(
+        Id: "TEST",
+        Shell: "wsl-ubuntu-24.04",
+        Workload: "test_workload",
+        Kpi: "throughput_bytes_per_sec",
+        FixturePath: "fixtures/test.txt",
+        FixtureKey: null,
+        WinttyConfigOverrides: FrozenDictionary<string, string>.Empty);
+
+    [Fact]
+    public void BuildShellCommandForCell_Pwsh_GeneratesUniqueScriptPathPerCall()
+    {
+        // Two consecutive calls for the same cell must return distinct script
+        // paths so a still-running prior iter cannot race the next iter's
+        // overwrite of a stable filename. See the BuildShellCommandForCell
+        // comment for the wsl-bash leftover-process race that motivated this.
+        var (_, path1) = ThroughputRunner.BuildShellCommandForCell(
+            PwshCell, "C:\\fixtures\\test.txt", "C:\\Temp\\sentinel-1.marker");
+        var (_, path2) = ThroughputRunner.BuildShellCommandForCell(
+            PwshCell, "C:\\fixtures\\test.txt", "C:\\Temp\\sentinel-2.marker");
+        try
+        {
+            Assert.NotEqual(path1, path2);
+            Assert.EndsWith(".ps1", path1);
+            Assert.EndsWith(".ps1", path2);
+            Assert.True(File.Exists(path1));
+            Assert.True(File.Exists(path2));
+        }
+        finally
+        {
+            try { if (File.Exists(path1)) File.Delete(path1); } catch (IOException) { }
+            try { if (File.Exists(path2)) File.Delete(path2); } catch (IOException) { }
+        }
+    }
+
+    [Fact]
+    public void BuildShellCommandForCell_Wsl_GeneratesUniqueScriptPathPerCall()
+    {
+        var (_, path1) = ThroughputRunner.BuildShellCommandForCell(
+            WslCell, "/mnt/c/fixtures/test.txt", "C:\\Temp\\sentinel-1.marker");
+        var (_, path2) = ThroughputRunner.BuildShellCommandForCell(
+            WslCell, "/mnt/c/fixtures/test.txt", "C:\\Temp\\sentinel-2.marker");
+        try
+        {
+            Assert.NotEqual(path1, path2);
+            Assert.EndsWith(".sh", path1);
+            Assert.EndsWith(".sh", path2);
+            Assert.True(File.Exists(path1));
+            Assert.True(File.Exists(path2));
+        }
+        finally
+        {
+            try { if (File.Exists(path1)) File.Delete(path1); } catch (IOException) { }
+            try { if (File.Exists(path2)) File.Delete(path2); } catch (IOException) { }
+        }
+    }
+
+    [Fact]
+    public void BuildShellCommandForCell_ScriptStemIncludesCellId()
+    {
+        // Cell.Id is part of the stem so that the wintty-bench-scripts dir
+        // remains debuggable when multiple cells run in the same harness.
+        var (_, path) = ThroughputRunner.BuildShellCommandForCell(
+            PwshCell, "C:\\fixtures\\test.txt", "C:\\Temp\\sentinel.marker");
+        try
+        {
+            Assert.Contains("TEST-", Path.GetFileName(path));
+        }
+        finally
+        {
+            try { if (File.Exists(path)) File.Delete(path); } catch (IOException) { }
+        }
+    }
+}

--- a/harness.tests/Runners/ThroughputRunnerTests.cs
+++ b/harness.tests/Runners/ThroughputRunnerTests.cs
@@ -90,4 +90,47 @@ public class ThroughputRunnerTests
             try { if (File.Exists(path)) File.Delete(path); } catch (IOException) { }
         }
     }
+
+    [Fact]
+    public void BuildShellCommandForCell_Pwsh_ScriptBodyTouchesSentinel()
+    {
+        // Lock down the script-body contract the whole fix depends on:
+        // bash/pwsh actually touches the iter's specific sentinel, not the
+        // dir or some derived path.
+        var sentinel = "C:\\Temp\\unique-pwsh-sentinel.marker";
+        var (_, path) = ThroughputRunner.BuildShellCommandForCell(
+            PwshCell, "C:\\fixtures\\test.txt", sentinel);
+        try
+        {
+            var body = File.ReadAllText(path);
+            Assert.Contains(sentinel, body);
+            Assert.Contains("New-Item -ItemType File -Force -Path", body);
+        }
+        finally
+        {
+            try { if (File.Exists(path)) File.Delete(path); } catch (IOException) { }
+        }
+    }
+
+    [Fact]
+    public void BuildShellCommandForCell_Wsl_ScriptBodyTouchesSentinelInWslPath()
+    {
+        // The wsl variant must translate the Windows sentinel path to its
+        // /mnt/c/... form before emitting the touch; otherwise bash would
+        // try (and fail) to create a file at a path with a drive letter.
+        var sentinel = "C:\\Temp\\unique-wsl-sentinel.marker";
+        var (_, path) = ThroughputRunner.BuildShellCommandForCell(
+            WslCell, "/mnt/c/fixtures/test.txt", sentinel);
+        try
+        {
+            var body = File.ReadAllText(path);
+            Assert.Contains("/mnt/c/Temp/unique-wsl-sentinel.marker", body);
+            Assert.Contains("touch '", body);
+            Assert.DoesNotContain("C:\\", body);
+        }
+        finally
+        {
+            try { if (File.Exists(path)) File.Delete(path); } catch (IOException) { }
+        }
+    }
 }

--- a/harness/Runners/ThroughputRunner.cs
+++ b/harness/Runners/ThroughputRunner.cs
@@ -101,22 +101,25 @@ public sealed class ThroughputRunner : IKpiRunner
     internal static (string Command, string ScriptPath) BuildShellCommandForCell(
         Cell cell, string fixtureShellPath, string sentinelPath)
     {
-        // Ghostty's Windows termio wraps any command containing cmd.exe
-        // metacharacters ('|', '&', '<', '>', '(', ')', '^', '%', '!') in
-        // `cmd.exe /c ...`, which mangles nested quotes. Put the shell body
-        // in a temp script file instead so the `command = ...` value in
-        // the config is a plain argv with no shell metacharacters.
+        // PER-ITER UNIQUE script name (Guid suffix): each iter has its own
+        // file, so a still-running prior wsl-bash never observes the next
+        // iter's overwritten content. A stable name was racy because vmcompute-
+        // managed wsl processes survive Job.KILL_ON_JOB_CLOSE on the WT host;
+        // iter N's bash, on its next read, would see iter N+1's content and
+        // `touch` iter N+1's sentinel before iter N+1 even started its
+        // stopwatch.
         //
-        // Script names are PER-ITER unique (Guid suffix). A stable name was
-        // racy: if iter N's wsl-bash was still running (vmcompute-managed
-        // wsl processes survive Job.KILL_ON_JOB_CLOSE on the WT host),
-        // iter N+1's overwrite of the same path could be observed by iter
-        // N's bash on its next read, which would then `touch` iter N+1's
-        // sentinel before iter N+1 even started its stopwatch.
+        // The script-on-disk approach (rather than inlining into commandline)
+        // exists because Ghostty's Windows termio wraps any command containing
+        // cmd.exe metacharacters ('|', '&', '<', '>', '(', ')', '^', '%', '!')
+        // in `cmd.exe /c ...`, which mangles nested quotes. Putting the shell
+        // body in a temp script file keeps the `command = ...` value in the
+        // config a plain argv with no shell metacharacters.
         var scriptsDir = Path.Combine(Path.GetTempPath(), "wintty-bench-scripts");
         Directory.CreateDirectory(scriptsDir);
-        var scriptStem = string.Create(System.Globalization.CultureInfo.InvariantCulture,
-            $"{cell.Id}-{Guid.NewGuid():N}");
+        // Guid:N is hex-only and locale-invariant by definition; no IFormat-
+        // Provider needed.
+        var scriptStem = $"{cell.Id}-{Guid.NewGuid():N}";
 
         return cell.Shell switch
         {

--- a/harness/Runners/ThroughputRunner.cs
+++ b/harness/Runners/ThroughputRunner.cs
@@ -41,7 +41,7 @@ public sealed class ThroughputRunner : IKpiRunner
                 $"wintty-bench-done-{Guid.NewGuid():N}.marker");
             if (File.Exists(sentinelPath)) File.Delete(sentinelPath);
 
-            var shellCmd = BuildShellCommandForCell(cell, handle.ShellPath, sentinelPath);
+            var (shellCmd, scriptPath) = BuildShellCommandForCell(cell, handle.ShellPath, sentinelPath);
 
             var launch = launcher.Launch(new LaunchRequest(
                 TargetExePath: targetExePath,
@@ -72,6 +72,13 @@ public sealed class ThroughputRunner : IKpiRunner
                 launch.Dispose();
                 try { if (File.Exists(sentinelPath)) File.Delete(sentinelPath); }
                 catch (IOException) { /* best effort */ }
+                // Per-iter script cleanup matches the per-iter script naming
+                // (see BuildShellCommandForCell). Leftover scripts would
+                // accumulate slowly but more importantly an orphan wsl-bash
+                // from a still-running prior iter could no longer race the
+                // next iter's overwrite -- each iter has its own file.
+                try { if (File.Exists(scriptPath)) File.Delete(scriptPath); }
+                catch (IOException) { /* best effort */ }
             }
 
             if (!isWarmup)
@@ -91,27 +98,38 @@ public sealed class ThroughputRunner : IKpiRunner
         return samples;
     }
 
-    private static string BuildShellCommandForCell(Cell cell, string fixtureShellPath, string sentinelPath)
+    internal static (string Command, string ScriptPath) BuildShellCommandForCell(
+        Cell cell, string fixtureShellPath, string sentinelPath)
     {
         // Ghostty's Windows termio wraps any command containing cmd.exe
         // metacharacters ('|', '&', '<', '>', '(', ')', '^', '%', '!') in
         // `cmd.exe /c ...`, which mangles nested quotes. Put the shell body
         // in a temp script file instead so the `command = ...` value in
         // the config is a plain argv with no shell metacharacters.
+        //
+        // Script names are PER-ITER unique (Guid suffix). A stable name was
+        // racy: if iter N's wsl-bash was still running (vmcompute-managed
+        // wsl processes survive Job.KILL_ON_JOB_CLOSE on the WT host),
+        // iter N+1's overwrite of the same path could be observed by iter
+        // N's bash on its next read, which would then `touch` iter N+1's
+        // sentinel before iter N+1 even started its stopwatch.
         var scriptsDir = Path.Combine(Path.GetTempPath(), "wintty-bench-scripts");
         Directory.CreateDirectory(scriptsDir);
+        var scriptStem = string.Create(System.Globalization.CultureInfo.InvariantCulture,
+            $"{cell.Id}-{Guid.NewGuid():N}");
 
         return cell.Shell switch
         {
-            "pwsh-7.4" => BuildPwshCommand(cell, fixtureShellPath, scriptsDir, sentinelPath),
-            "wsl-ubuntu-24.04" => BuildWslCommand(cell, fixtureShellPath, scriptsDir, sentinelPath),
+            "pwsh-7.4" => BuildPwshCommand(fixtureShellPath, scriptsDir, scriptStem, sentinelPath),
+            "wsl-ubuntu-24.04" => BuildWslCommand(fixtureShellPath, scriptsDir, scriptStem, sentinelPath),
             _ => throw new NotSupportedException($"Shell '{cell.Shell}' not supported"),
         };
     }
 
-    private static string BuildPwshCommand(Cell cell, string fixtureAbs, string scriptsDir, string sentinelPath)
+    private static (string Command, string ScriptPath) BuildPwshCommand(
+        string fixtureAbs, string scriptsDir, string scriptStem, string sentinelPath)
     {
-        var scriptPath = Path.Combine(scriptsDir, $"{cell.Id}.ps1");
+        var scriptPath = Path.Combine(scriptsDir, scriptStem + ".ps1");
         // Single-quoted pwsh literals assume no apostrophes in fixtureAbs or
         // sentinelPath. Current callers pass repo-rooted fixture paths and
         // %TEMP%-derived sentinel paths; both are apostrophe-free on Windows.
@@ -122,13 +140,15 @@ public sealed class ThroughputRunner : IKpiRunner
         File.WriteAllText(scriptPath, body);
         // -NoProfile skips ~1-2s of profile loading per launch. -NonInteractive
         // guarantees no hidden prompt can wedge the measurement.
-        return string.Create(CultureInfo.InvariantCulture,
+        var command = string.Create(CultureInfo.InvariantCulture,
             $"pwsh -NoProfile -NonInteractive -NoLogo -File {scriptPath}");
+        return (command, scriptPath);
     }
 
-    private static string BuildWslCommand(Cell cell, string fixtureWslPath, string scriptsDir, string sentinelPath)
+    private static (string Command, string ScriptPath) BuildWslCommand(
+        string fixtureWslPath, string scriptsDir, string scriptStem, string sentinelPath)
     {
-        var scriptPath = Path.Combine(scriptsDir, $"{cell.Id}.sh");
+        var scriptPath = Path.Combine(scriptsDir, scriptStem + ".sh");
         var sentinelWsl = WslPaths.ToWslMountPath(sentinelPath);
         // LF line endings: bash under WSL rejects CRLF script lines. The
         // Replace is defensive — string.Create with \n literals never inserts
@@ -138,7 +158,8 @@ public sealed class ThroughputRunner : IKpiRunner
             $"cat '{fixtureWslPath}'\ntouch '{sentinelWsl}'\nexit\n");
         File.WriteAllText(scriptPath, body.Replace("\r\n", "\n", StringComparison.Ordinal));
         var scriptWsl = WslPaths.ToWslMountPath(scriptPath);
-        return string.Create(CultureInfo.InvariantCulture,
+        var command = string.Create(CultureInfo.InvariantCulture,
             $"wsl -d Ubuntu-24.04 bash {scriptWsl}");
+        return (command, scriptPath);
     }
 }


### PR DESCRIPTION
## Why

After PR # 15 sped up the WT launch path, wsl-shell throughput cells (C5/C2b/C10/C11) started reporting impossible throughput (~446 MB/s for a 138 KB fixture in ~0.3 ms). Diagnosed in # 16 as a script-overwrite race: `ThroughputRunner` wrote a stable-path script per iter, and a still-running prior wsl-bash (vmcompute-managed processes are not reaped by `Job.KILL_ON_JOB_CLOSE` on the WT host) could observe iter N+1's overwrite on its next read, then `touch` iter N+1's sentinel before iter N+1 even started its stopwatch.

## What

Make the script filename per-iter unique (`<cell.Id>-<guid>.{sh|ps1}`). Each iter has its own file, so a still-running prior bash reads its own content rather than the next iter's overwritten content. The runner deletes the script in the finally block (best-effort) so `wintty-bench-scripts` does not grow unbounded.

`BuildShellCommandForCell` is now `internal` and returns `(string Command, string ScriptPath)` so the runner can clean up.

## Verification

`dotnet run -- --mode=ci --cells=C5 --terminals=wt --target-wt=auto`:

| Metric | Before (racing) | After |
|---|---|---|
| p50 | 446,116,129 B/s | **1,009,276 B/s** |
| p95 | 513,168,278 B/s | 1,544,410 B/s |
| stddev | 271,376,561 | 407,099 (~666x tighter) |

Per-iter range: 407 kB/s - 1.56 MB/s, no extreme outliers.

Closes # 16.