### PR TITLE
fix(throughput-runner): cursor-query timing for accurate WT throughput

### DIFF
--- a/harness.tests/Runners/ThroughputRunnerTests.cs
+++ b/harness.tests/Runners/ThroughputRunnerTests.cs
@@ -133,4 +133,68 @@ public class ThroughputRunnerTests
             try { if (File.Exists(path)) File.Delete(path); } catch (IOException) { }
         }
     }
+
+    [Fact]
+    public void BuildShellCommandForCell_Pwsh_QueriesCursorPositionBeforeSentinel()
+    {
+        // Without the cursor-position query the done sentinel can fire before
+        // the terminal has actually rendered the workload (WT does not back-
+        // pressure stdout the way ConPTY does for wintty). Writing CSI 6 n
+        // and reading the reply forces the terminal to parse and render every
+        // preceding byte before responding, so the touch correlates with
+        // "render complete" rather than "stdout buffered."
+        var sentinel = "C:\\Temp\\cursor-query-pwsh.marker";
+        var (_, path) = ThroughputRunner.BuildShellCommandForCell(
+            PwshCell, "C:\\fixtures\\test.txt", sentinel);
+        try
+        {
+            var body = File.ReadAllText(path);
+            var workloadIdx = body.IndexOf("Get-Content", StringComparison.Ordinal);
+            var queryIdx = body.IndexOf("[6n", StringComparison.Ordinal);
+            var readIdx = body.IndexOf("[Console]::Read()", StringComparison.Ordinal);
+            var sentinelIdx = body.IndexOf("New-Item", StringComparison.Ordinal);
+
+            Assert.True(workloadIdx >= 0, "Get-Content workload must be present");
+            Assert.True(queryIdx >= 0, "CSI 6 n cursor-position query must be present");
+            Assert.True(readIdx >= 0, "stdin read of cursor reply must be present");
+            Assert.True(sentinelIdx >= 0, "sentinel touch must be present");
+            Assert.True(workloadIdx < queryIdx, "workload must precede cursor query");
+            Assert.True(queryIdx < readIdx, "cursor query must precede stdin read");
+            Assert.True(readIdx < sentinelIdx, "stdin read must precede sentinel touch");
+        }
+        finally
+        {
+            try { if (File.Exists(path)) File.Delete(path); } catch (IOException) { }
+        }
+    }
+
+    [Fact]
+    public void BuildShellCommandForCell_Wsl_QueriesCursorPositionBeforeSentinel()
+    {
+        var sentinel = "C:\\Temp\\cursor-query-wsl.marker";
+        var (_, path) = ThroughputRunner.BuildShellCommandForCell(
+            WslCell, "/mnt/c/fixtures/test.txt", sentinel);
+        try
+        {
+            var body = File.ReadAllText(path);
+            var workloadIdx = body.IndexOf("cat '", StringComparison.Ordinal);
+            // \033[6n is the bash-printf escape form; the literal "[6n" is
+            // what survives in the script source.
+            var queryIdx = body.IndexOf("[6n", StringComparison.Ordinal);
+            var readIdx = body.IndexOf("read ", StringComparison.Ordinal);
+            var sentinelIdx = body.IndexOf("touch '", StringComparison.Ordinal);
+
+            Assert.True(workloadIdx >= 0, "cat workload must be present");
+            Assert.True(queryIdx >= 0, "CSI 6 n cursor-position query must be present");
+            Assert.True(readIdx >= 0, "bash read of cursor reply must be present");
+            Assert.True(sentinelIdx >= 0, "sentinel touch must be present");
+            Assert.True(workloadIdx < queryIdx, "workload must precede cursor query");
+            Assert.True(queryIdx < readIdx, "cursor query must precede stdin read");
+            Assert.True(readIdx < sentinelIdx, "stdin read must precede sentinel touch");
+        }
+        finally
+        {
+            try { if (File.Exists(path)) File.Delete(path); } catch (IOException) { }
+        }
+    }
 }

--- a/harness.tests/Runners/ThroughputRunnerTests.cs
+++ b/harness.tests/Runners/ThroughputRunnerTests.cs
@@ -181,7 +181,10 @@ public class ThroughputRunnerTests
             // \033[6n is the bash-printf escape form; the literal "[6n" is
             // what survives in the script source.
             var queryIdx = body.IndexOf("[6n", StringComparison.Ordinal);
-            var readIdx = body.IndexOf("read ", StringComparison.Ordinal);
+            // Pin the exact line that consumes the reply, not just any
+            // "read " token, so a future reformat can't slide an unrelated
+            // command into this assertion's path.
+            var readIdx = body.IndexOf("IFS= read", StringComparison.Ordinal);
             var sentinelIdx = body.IndexOf("touch '", StringComparison.Ordinal);
 
             Assert.True(workloadIdx >= 0, "cat workload must be present");

--- a/harness/Runners/ThroughputRunner.cs
+++ b/harness/Runners/ThroughputRunner.cs
@@ -11,6 +11,18 @@ namespace WinttyBench.Runners;
 // even with quit-after-last-window-closed=true in config, so the harness
 // drives the lifecycle itself: wait for a sentinel file that the shell
 // script writes on its last line, then stop the clock and kill Wintty.
+//
+// The script issues a CSI 6 n (DSR cursor-position request) AFTER the
+// workload and reads the terminal's reply BEFORE touching the sentinel.
+// A terminal must parse and render every preceding byte to compute the
+// reply, so the touch correlates with "render complete" rather than
+// "stdout buffered." Without this, WT scores ~5,000-30,000x faster than
+// reality because its profile commandline is spawned BEFORE the CASCADIA
+// HWND becomes detectable to WaitForNewWtHwnd, so a fast script can
+// drain its workload into ConPTY's buffer and signal done while Launch
+// is still polling for the window. Wintty doesn't have this problem
+// because its ConPTY back-pressures stdout, but the cursor-query path
+// is a no-op cost there and a correctness fix for WT.
 public sealed class ThroughputRunner : IKpiRunner
 {
     public IReadOnlyList<string> SupportedTerminals { get; } = ["wintty", "wt"];
@@ -138,8 +150,14 @@ public sealed class ThroughputRunner : IKpiRunner
         // %TEMP%-derived sentinel paths; both are apostrophe-free on Windows.
         // If a future cell points at a path containing `'`, this needs `''`
         // doubling to stay literal.
+        //
+        // Backtick-e is the PowerShell 6+ escape literal (0x1B). The reply
+        // from CSI 6 n is `ESC [ <row> ; <col> R`, terminating in 'R' (0x52).
+        // The Read loop tolerates -1 (EOF, terminal closed early) so a hung
+        // iter still falls through to the runner's DefaultExitTimeout instead
+        // of wedging here.
         var body = string.Create(CultureInfo.InvariantCulture,
-            $"Get-Content -Raw -LiteralPath '{fixtureAbs}' | Write-Host -NoNewline\nNew-Item -ItemType File -Force -Path '{sentinelPath}' | Out-Null\nexit\n");
+            $"Get-Content -Raw -LiteralPath '{fixtureAbs}' | Write-Host -NoNewline\n[Console]::Out.Write(\"`e[6n\")\n[Console]::Out.Flush()\nwhile ($true) {{ $c = [Console]::Read(); if ($c -eq -1 -or $c -eq 82) {{ break }} }}\nNew-Item -ItemType File -Force -Path '{sentinelPath}' | Out-Null\nexit\n");
         File.WriteAllText(scriptPath, body);
         // -NoProfile skips ~1-2s of profile loading per launch. -NonInteractive
         // guarantees no hidden prompt can wedge the measurement.
@@ -157,8 +175,16 @@ public sealed class ThroughputRunner : IKpiRunner
         // Replace is defensive — string.Create with \n literals never inserts
         // CRLF today, but a future edit that switches to a template file or
         // verbatim string could, and this keeps the invariant loud.
+        //
+        // stty -icanon disables line-buffering so `read -d R` can return on
+        // the 'R' that ends the CSI 6 n reply (\e[<row>;<col>R) instead of
+        // waiting for a newline that never arrives. -echo prevents the reply
+        // bytes from being echoed back to the terminal as visible text. The
+        // 2>/dev/null tolerates wintty raw-pipe mode where stdin is not a
+        // tty and stty errors out; in that mode `read` still works because
+        // it just consumes bytes from the pipe.
         var body = string.Create(CultureInfo.InvariantCulture,
-            $"cat '{fixtureWslPath}'\ntouch '{sentinelWsl}'\nexit\n");
+            $"cat '{fixtureWslPath}'\nstty -icanon -echo 2>/dev/null\nprintf '\\033[6n'\nIFS= read -rs -d R _resp\ntouch '{sentinelWsl}'\nexit\n");
         File.WriteAllText(scriptPath, body.Replace("\r\n", "\n", StringComparison.Ordinal));
         var scriptWsl = WslPaths.ToWslMountPath(scriptPath);
         var command = string.Create(CultureInfo.InvariantCulture,


### PR DESCRIPTION
Closes #18.

After the workload the script writes CSI 6 n and reads the reply before touching the done sentinel. A terminal must render every preceding byte to compute the reply, so the touch correlates with render-complete instead of buffer-drained.

WT scores were inflated 5,000-30,000x because its profile commandline runs before the CASCADIA HWND is detectable to WaitForNewWtHwnd, so a fast script could drain into ConPTY and signal done while Launch was still polling for the window. Wintty was unaffected because its ConPTY back-pressures stdout.

Pwsh uses `[Console]::Read()` until 0x52 ('R'). Bash uses `stty -icanon -echo` then `read -d R` (stty error suppressed for raw-pipe mode where stdin is not a tty).

Smoke result: WT C5 dropped from ~422 MB/s (buffer-drain, fictional) to 267 kB/s (parser + grid-update time). 7,000x correction, in the same order of magnitude as wintty.

## Known limitation

CSI 6 n proves the parser consumed every byte (cursor position is a parser+grid-state query). It does NOT prove the renderer painted those bytes to the screen. A terminal whose parser thread replies to DSR while a separate render thread paints async will reply from grid state without waiting for paint. Tracked in # 21 for a future paint-time KPI; not blocking this fix because the comparison-not-fiction goal of # 18 is met.

## Test plan
- [x] dotnet test: 167 passing, 5 integration skipped, 2 new ordering assertions
- [x] pwsh + bash bodies parse cleanly
- [x] both read loops terminate on synthetic CSI reply piped to stdin
- [x] Smoke WT C5: 267 kB/s post-fix vs ~422 MB/s pre-fix
- [ ] Smoke wintty C5: number stays in baseline range (cursor query should be no-op overhead)
- [ ] Follow-up: README "NOT directly comparable" caveat once wintty smoke confirms parity