### PR TITLE
fix(throughput-runner): use ReadKey for cursor reply under cooked CONIN$

### DIFF
--- a/harness.tests/Runners/ThroughputRunnerTests.cs
+++ b/harness.tests/Runners/ThroughputRunnerTests.cs
@@ -151,7 +151,10 @@ public class ThroughputRunnerTests
             var body = File.ReadAllText(path);
             var workloadIdx = body.IndexOf("Get-Content", StringComparison.Ordinal);
             var queryIdx = body.IndexOf("[6n", StringComparison.Ordinal);
-            var readIdx = body.IndexOf("[Console]::Read()", StringComparison.Ordinal);
+            // ReadKey, not Read, because Read() blocks under cooked-mode
+            // CONIN$ which is what pwsh sees when launched by a real
+            // terminal. See BuildPwshCommand for the rationale.
+            var readIdx = body.IndexOf("[Console]::ReadKey", StringComparison.Ordinal);
             var sentinelIdx = body.IndexOf("New-Item", StringComparison.Ordinal);
 
             Assert.True(workloadIdx >= 0, "Get-Content workload must be present");

--- a/harness/Runners/ThroughputRunner.cs
+++ b/harness/Runners/ThroughputRunner.cs
@@ -152,12 +152,19 @@ public sealed class ThroughputRunner : IKpiRunner
         // doubling to stay literal.
         //
         // Backtick-e is the PowerShell 6+ escape literal (0x1B). The reply
-        // from CSI 6 n is `ESC [ <row> ; <col> R`, terminating in 'R' (0x52).
-        // The Read loop tolerates -1 (EOF, terminal closed early) so a hung
-        // iter still falls through to the runner's DefaultExitTimeout instead
-        // of wedging here.
+        // from CSI 6 n is `ESC [ <row> ; <col> R`, terminating in 'R'.
+        //
+        // ReadKey($true) instead of Read() because pwsh's stdin under a
+        // ConPTY-attached terminal is a real console handle in cooked /
+        // line-buffered mode by default -- Read() blocks until newline,
+        // which the cursor reply never sends. ReadKey pulls events out of
+        // the console input buffer directly, bypassing line buffering;
+        // the $true arg suppresses the otherwise-default on-screen echo
+        // of the reply bytes. If the terminal closes early ReadKey throws,
+        // the sentinel never touches, and the runner's DefaultExitTimeout
+        // marks the iter hung -- same end state as a real timeout.
         var body = string.Create(CultureInfo.InvariantCulture,
-            $"Get-Content -Raw -LiteralPath '{fixtureAbs}' | Write-Host -NoNewline\n[Console]::Out.Write(\"`e[6n\")\n[Console]::Out.Flush()\nwhile ($true) {{ $c = [Console]::Read(); if ($c -eq -1 -or $c -eq 82) {{ break }} }}\nNew-Item -ItemType File -Force -Path '{sentinelPath}' | Out-Null\nexit\n");
+            $"Get-Content -Raw -LiteralPath '{fixtureAbs}' | Write-Host -NoNewline\n[Console]::Out.Write(\"`e[6n\")\n[Console]::Out.Flush()\nwhile ($true) {{ if ([Console]::ReadKey($true).KeyChar -eq 'R') {{ break }} }}\nNew-Item -ItemType File -Force -Path '{sentinelPath}' | Out-Null\nexit\n");
         File.WriteAllText(scriptPath, body);
         // -NoProfile skips ~1-2s of profile loading per launch. -NonInteractive
         // guarantees no hidden prompt can wedge the measurement.


### PR DESCRIPTION
Hotfix follow-up to # 20.

# 20 shipped `[Console]::Read()` to consume the CSI 6 n cursor-position reply, which hangs in production. Pwsh under a ConPTY-attached terminal sees stdin as a real console handle in cooked / line-buffered mode by default; Read() blocks until a newline that the cursor reply never sends. Smoke under WT showed `^[[28;7R` rendered as visible text on screen (default console echo) while the script wedged in Read(), eventually timing out as a hung iter.

ReadKey($true) pulls events out of the console input buffer directly, bypassing line buffering. The $true arg suppresses on-screen echo of the reply bytes.

The bash path is unaffected -- it already disables cooked mode via `stty -icanon -echo` before the read.

## Why # 20 missed this

I runtime-tested # 20 with `$reply | pwsh -File <script>`, which redirects pwsh's stdin to a pipe. Pipes are not cooked-mode, so Read() returned each byte immediately. I noted in the # 20 PR description that the production scenario uses ConPTY-attached console handles which may behave differently, but accepted the redirected-stdin smoke as sufficient. It wasn't.

## Smoke result

Run with `--cells=C1,C5 --terminals=wintty,wt`:

| Cell | wintty | wt | Verdict |
|------|--------|-----|---------|
| C1 (pwsh dense_cells, 2.6 MB) | 1.35 MB/s | 3.07 MB/s | sane (within 30% of baseline; WT 2.3x wintty is plausible) |
| C5 (wsl unicode, 138 KB) | 38.3 kB/s | 505 MB/s | wintty within 37% of baseline; WT FICTIONAL |

The pwsh path (C1) is fixed end-to-end. The bash path on WT (C5) regressed back to the buffer-drain regime: 138 KB / 505 MB/s = 273 us/iter, faster than `wsl.exe` can spawn. # 20's earlier C5/wt smoke at 267 kB/s was reproducible-once but not reliable -- something about WT's bash/WSL stdin chain doesn't deliver the cursor reply consistently to `read -d R`. Will be tracked as a separate issue and ultimately resolved by # 21 (paint-time KPI), which doesn't depend on cursor-query plumbing.

## Test plan

- [x] dotnet test: 167 passing, 5 integration skipped, all ordering assertions still hold (test substring updated to `[Console]::ReadKey`)
- [x] pwsh body parses cleanly via `Parser.ParseFile`
- [x] Smoke under real ConPTY: pwsh path no longer hangs on either terminal
- [x] C1 numbers within range on both terminals
- [ ] Bash/WT cursor-query reliability -- separate follow-up issue
- [ ] README "NOT directly comparable" caveat -- stays as-is until bash/WT or # 21 lands