### PR TITLE
diag(throughput-runner): capture stty/read exit for wsl bash under WT

### DIFF
--- a/harness.tests/Runners/ThroughputRunnerTests.cs
+++ b/harness.tests/Runners/ThroughputRunnerTests.cs
@@ -203,4 +203,51 @@ public class ThroughputRunnerTests
             try { if (File.Exists(path)) File.Delete(path); } catch (IOException) { }
         }
     }
+
+    [Fact]
+    public void BuildShellCommandForCell_Wsl_CapturesDiagnosticsToSiblingLog()
+    {
+        // The wsl path is suspected of returning fast under WT because `read
+        // -d R` hits EOF (stdin closed by ConPTY chain) and bash silently
+        // continues to touch the sentinel. The script captures stty exit,
+        // read exit, and the byte-length of the response into a sibling .log
+        // file so a real WT smoke produces concrete evidence per iter. The
+        // log file shares the script's basename and lives next to it; the
+        // runner deletes the .sh on exit but does not touch the .log, so it
+        // persists for post-run inspection.
+        var sentinel = "C:\\Temp\\diag-wsl-sentinel.marker";
+        var (_, path) = ThroughputRunner.BuildShellCommandForCell(
+            WslCell, "/mnt/c/fixtures/test.txt", sentinel);
+        try
+        {
+            var body = File.ReadAllText(path);
+            var expectedLogStem = Path.GetFileNameWithoutExtension(path);
+
+            // The log path inside the script body is in WSL form, but it
+            // must mention the same stem as the .sh on disk so the user can
+            // map "which iter is this log".
+            Assert.Contains(expectedLogStem + ".log", body);
+            // stty exit code captured. The 2>/dev/null hides the stderr
+            // message but not the exit status; record it.
+            Assert.Contains("stty_exit=", body);
+            // read exit code is the smoking gun for the EOF hypothesis.
+            // Bash's read returns >0 on EOF without a delimiter; if WT
+            // closes stdin pre-emptively this prints 1 and the script
+            // falls through.
+            Assert.Contains("read_exit=", body);
+            // Length of what was actually consumed from stdin. 0 = nothing
+            // arrived; non-zero with read_exit=0 = reply parsed correctly.
+            Assert.Contains("resp_len=", body);
+            // Sentinel touch is still the last functional step. Diagnostic
+            // capture must not gate it; an unconditional touch keeps the
+            // runner contract intact.
+            var readIdx = body.IndexOf("IFS= read", StringComparison.Ordinal);
+            var touchIdx = body.IndexOf("touch '", StringComparison.Ordinal);
+            Assert.True(readIdx < touchIdx, "diagnostics must not move the sentinel touch");
+        }
+        finally
+        {
+            try { if (File.Exists(path)) File.Delete(path); } catch (IOException) { }
+        }
+    }
 }

--- a/harness/Runners/ThroughputRunner.cs
+++ b/harness/Runners/ThroughputRunner.cs
@@ -178,6 +178,12 @@ public sealed class ThroughputRunner : IKpiRunner
     {
         var scriptPath = Path.Combine(scriptsDir, scriptStem + ".sh");
         var sentinelWsl = WslPaths.ToWslMountPath(sentinelPath);
+        // Sibling .log file next to the .sh; the runner deletes the script
+        // on iter exit but never touches the log, so it persists for post-
+        // run inspection. Per-iter unique because scriptStem already carries
+        // a Guid suffix, so concurrent or repeated iters never collide.
+        var logPath = Path.Combine(scriptsDir, scriptStem + ".log");
+        var logWsl = WslPaths.ToWslMountPath(logPath);
         // LF line endings: bash under WSL rejects CRLF script lines. The
         // Replace is defensive — string.Create with \n literals never inserts
         // CRLF today, but a future edit that switches to a template file or
@@ -190,8 +196,20 @@ public sealed class ThroughputRunner : IKpiRunner
         // 2>/dev/null tolerates wintty raw-pipe mode where stdin is not a
         // tty and stty errors out; in that mode `read` still works because
         // it just consumes bytes from the pipe.
+        //
+        // Diagnostic capture: stty/read exit codes plus the byte-length of
+        // the consumed response are appended to a sibling .log file. The
+        // hypothesis under WT is that `read -d R` hits EOF (read_exit=1,
+        // resp_len=0) because the WT->wsl.exe->bash stdin chain delivers
+        // nothing for the cursor-position reply, so bash falls through to
+        // the unconditional touch in microseconds. Concrete per-iter numbers
+        // here discriminate that from a working-but-slow wintty case
+        // (read_exit=0, resp_len in single digits). $? is captured into
+        // locals on the line immediately after the command being measured,
+        // because every intervening builtin (including the redirect itself
+        // in some bash versions) can clobber it.
         var body = string.Create(CultureInfo.InvariantCulture,
-            $"cat '{fixtureWslPath}'\nstty -icanon -echo 2>/dev/null\nprintf '\\033[6n'\nIFS= read -rs -d R _resp\ntouch '{sentinelWsl}'\nexit\n");
+            $"cat '{fixtureWslPath}'\nstty -icanon -echo 2>/dev/null\n_stty_exit=$?\nprintf '\\033[6n'\nIFS= read -rs -d R _resp\n_read_exit=$?\nprintf 'ts=%s stty_exit=%s read_exit=%s resp_len=%s\\n' \"$(date +%s.%N)\" \"$_stty_exit\" \"$_read_exit\" \"${{#_resp}}\" >> '{logWsl}'\ntouch '{sentinelWsl}'\nexit\n");
         File.WriteAllText(scriptPath, body.Replace("\r\n", "\n", StringComparison.Ordinal));
         var scriptWsl = WslPaths.ToWslMountPath(scriptPath);
         var command = string.Create(CultureInfo.InvariantCulture,


### PR DESCRIPTION
## Why

Under WT the wsl bash cell (C5) returns ~273us per iter for a 138 KB fixture (505 MB/s, faster than wsl.exe can spawn). The same script under wintty returns 38 kB/s, a real gated number. The cursor-position reply (`\e[6n`) is not making it back to bash's `read -d R` in the WT chain, but the script has no `set -e` and no exit-status check, so bash silently falls through to the unconditional `touch sentinel`.

Several hypotheses fit (stdin closed by WT->wsl.exe->bash forwarding, stty silently failing, race between reply arrival and read), and they cannot be discriminated from code reading alone. Fixing speculatively burns a smoke-run cycle per attempt.

## What

Append `stty_exit`, `read_exit`, and `${#_resp}` to a sibling `.log` file next to the per-iter `.sh`. The runner already deletes the script on exit but never touches the log, so each iter leaves a one-line record:

`ts=<unix.ns> stty_exit=<n> read_exit=<n> resp_len=<n>`

No behavioural change for the hot path: workload, cursor query, sentinel touch in the same order; diagnostics ride alongside.

## Smoke command

From a real pwsh terminal (cannot smoke from Claude Code per ConPTY/MSYS2 pty inheritance issue):

`````pwsh
cd C:\Users\Alessandro\CODE\OSS\wintty-bench
Remove-Item ${env:TEMP}\wintty-bench-scripts\*.log -ErrorAction SilentlyContinue
dotnet run --project harness -- --mode=ci --cells=C5 --terminals=wt --target-wt=auto
Get-Content ${env:TEMP}\wintty-bench-scripts\C5-*.log
`````

Then the same with `--terminals=wintty` to compare.

## What to look for

| Pattern | Interpretation |
|---------|----------------|
| `read_exit=1 resp_len=0` | Stdin EOF -- WT chain is closing/not delivering the reply (primary hypothesis). |
| `read_exit=0 resp_len > 0` | Read worked. If WT throughput still looks fake, something else is timing wrong. |
| `stty_exit != 0` | Stty failed (stdin not a tty). The `2>/dev/null` was masking this. |
| `resp_len > 0` but huge | Reply mixed with workload bytes -- need a different consumer than `-d R`. |

The wintty run should produce `read_exit=0 resp_len in 6..12` (length of `\e[<row>;<col>` minus the trailing R). That gives a baseline.

## Out of scope

Picking the actual fix. Options sketched in #23 (`< /dev/tty`, `dd bs=1 count=64`, `read -t 30`) all read like guesses without the log evidence. Next PR will use whatever the smoke proves.

## Tests

`dotnet test --project harness.tests/harness.tests.csproj` -- 168/173 (5 skipped integration); new test `BuildShellCommandForCell_Wsl_CapturesDiagnosticsToSiblingLog` asserts the script body contract.

Refs #23